### PR TITLE
fix: deposit with "FlexibleBoth", repay_add_liquidity error

### DIFF
--- a/packages/zap/src/modules/zapModule.ts
+++ b/packages/zap/src/modules/zapModule.ts
@@ -665,7 +665,8 @@ export class ZapModule implements IModule<CetusZapSDK> {
 
       const primaryCoinAInputs = isOnlyCoinA ? CoinAssist.getCoinAmountObjId(coinInputA, amount_a) : swap_out_coin
       const primaryCoinBInputs = isOnlyCoinA ? swap_out_coin : CoinAssist.getCoinAmountObjId(coinInputB, amount_b)
-
+      // reverse fixed_liquidity_coin_a
+      options.deposit_obj.fixed_liquidity_coin_a = !options.deposit_obj.fixed_liquidity_coin_a
       // Add liquidity
       await this.buildAddLiquidityPayload(
         options,
@@ -677,6 +678,8 @@ export class ZapModule implements IModule<CetusZapSDK> {
         tx,
         isOpenPosition
       )
+      // reverse fixed_liquidity_coin_a
+      options.deposit_obj.fixed_liquidity_coin_a = !options.deposit_obj.fixed_liquidity_coin_a
     } else {
       coinInputA = CoinAssist.buildMultiCoinInput(tx, allCoinAsset, coin_type_a, [BigInt(fixed_amount_a)])
       coinInputB = CoinAssist.buildMultiCoinInput(tx, allCoinAsset, coin_type_b, [BigInt(fixed_amount_b)])


### PR DESCRIPTION
## Description

the feature of Deposit FlexibleBoth is not working, the log is as follows:  


  devInspectTransactionBlock error Error: Dry run failed, could not automatically determine a budget: MoveAbort(MoveLocation { module: ModuleId { address: b2db7142fa83210a7d78d9c12ac49c043b3cbbd482224fea6e3da00aa5a5ae2d, name: Identifier("pool_script_v2") }, function: 23, instruction: 29, function_name: Some("repay_add_liquidity") }, 0) in command 5

## Cause of Bug (if applicable)

as shown in following：
![image](https://github.com/user-attachments/assets/ce36d5ff-6d06-4f65-bfde-e95c744f63fe)
![image](https://github.com/user-attachments/assets/eca3c269-ba5b-435f-9f0e-41acf66f7540)

in the sub deposit , fixed_liquidity_coin_a should be false, but buildAddLiquidityPayload inside sub_deposit_result use options as same as outside

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Tests added or updated
- [ ] Other (please describe):

## Related Issue

[repay_add_liquidity error when FlexibleBoth deposit #1](https://github.com/CetusProtocol/cetus-sdk-v2/issues/1)

## How Has This Been Tested?

- [x] pnpm test with jest

